### PR TITLE
Research compendium 2.0

### DIFF
--- a/.Rprofile
+++ b/.Rprofile
@@ -1,0 +1,1 @@
+source("renv/activate.R")

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,7 @@ code/misc
 *.tex
 *.gz
 .Rbuildignore
+
+.Renviron
+
+renv/

--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,5 @@ code/misc
 .Renviron
 
 renv/
+
+data/processed/

--- a/README.Rmd
+++ b/README.Rmd
@@ -1,5 +1,3 @@
-<!-- README.md is generated from README.Rmd. Please edit that file -->
-
 # ENSO
 
 This repository contains the code and data for the article
@@ -41,39 +39,3 @@ Zenodo deposit
 The directory `code` contains script files for all analysis steps.
 
 The directory `R` contains helper functions for the analysis and the visualisations.
-
-### Run workflow
-
-**Prerequisites**
-
-Create an [Earthdata login](https://urs.earthdata.nasa.gov/) and add an `.Renviron` file with the following content (note this intentionally overwrites other files, e.g. `~/.Renviron`):
-
-```
-EARTHDATA_USER=<your username>
-EARTHDATA_PASS=<your password>
-```
-
-Now restart R so the environment variables are picked up.
-
-Next, run the data download script.
-
-```{r data_download, eval=FALSE}
-source(here::here("code/00_modis_download.R"))
-```
-
-```{r analysis_steps, eval=FALSE}
-source(here("code/11_prep_data.R"))
-source(here("code/12_study_area_ndvi.R"))
-source(here("code/13_descriptive_stats.R"))
-source(here("code/14_ordination.R"))
-source(here("code/15_modeling.R"))
-source(here("code/16_varpart.R"))
-source(here("code/17_irrigation_nutrient_experiment.R"))
-source(here("code/18_appendix.R"))
-```
-
-``` r
-# render documents
-TODO
-```
-

--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
-
 # ENSO
+
+This repository contains the code and data for the article
+
+> TODO full citation of the article
+
+## Reproduce locally
 
 To install all required packages for this analysis, please execute
 
@@ -9,6 +14,6 @@ renv::install()
 ```
 
 from the repository root.
-The _renv_ package is the successor of the _packrat_ package and can be installed using `remotes::install_github("rstudio/renv")`.
+The _renv_ package is the successor of the _packrat_ package and can be [installed from CRAN](https://cran.r-project.org/package=renv).
 This will create a project-based R library with R packages being kept at a specific version for reproducibility. 
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This repository contains the code and data for the article
 
-> TODO full citation of the article
+> Muenchow, J., Dieker, P., Böttcher, T., Brock, J., Didenko, G., Fremout, T., Jakubka, D., Jentsch, A., Nüst, D., Richter, M., Rodríguez, E.F., Rodríguez, R.A., Rollenbeck, R., Salazar Zarsosa, P., Schratz, P. and Brenning, A. (2020), **Monitoring and predictive mapping of floristic biodiversity along a climatic gradient in ENSO's terrestrial core region, NW Peru**. Ecography. doi: [10.1111/ecog.05091](https://doi.org/10.1111/ecog.05091)
 
 ## Reproduce locally
 
@@ -15,5 +15,27 @@ renv::install()
 
 from the repository root.
 The _renv_ package is the successor of the _packrat_ package and can be [installed from CRAN](https://cran.r-project.org/package=renv).
-This will create a project-based R library with R packages being kept at a specific version for reproducibility. 
+This will create a project-based R library in a subdirectory `renv` based on the lockfile `renv.lock`, with R packages being kept at a specific version for better reproducibility.
 
+## Contents
+
+This repository contains the data, code, and text for the article and realises a [research compendium](https://research-compendium.science/).
+
+### Text
+
+The main body of the article can be found in `docs/enso_comp.Rmd`.
+This [R Markdown](https://rmarkdown.rstudio.com/) source be rendered to a PDF document for easier reading, printing, etc.
+The file `docs/supplementary_information.Rmd` contains Appendix 1-4 of the article.
+The file `docs/title_page.Rmd` contains the authors, article metadata, and abstract.
+
+### Data
+
+Zenodo deposit
+
+[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.3981436.svg)](https://doi.org/10.5281/zenodo.3981436)
+
+### Code
+
+Directory `R` ...
+
+Directory `code` ...

--- a/renv.lock
+++ b/renv.lock
@@ -1111,9 +1111,7 @@
     "renv": {
       "Package": "renv",
       "Version": "0.11.0",
-      "Source": "Repository",
-      "Repository": "CRAN",
-      "Hash": "1c3ef87cbb81c23ac96797781ec7aecc"
+      "Source": "Repository"
     },
     "reprex": {
       "Package": "reprex",

--- a/renv/.gitignore
+++ b/renv/.gitignore
@@ -1,0 +1,3 @@
+library/
+python/
+staging/

--- a/renv/activate.R
+++ b/renv/activate.R
@@ -2,7 +2,7 @@
 local({
 
   # the requested version of renv
-  version <- "0.11.0"
+  version <- "0.12.0"
 
   # the project directory
   project <- getwd()

--- a/renv/activate.R
+++ b/renv/activate.R
@@ -2,7 +2,7 @@
 local({
 
   # the requested version of renv
-  version <- "0.12.0"
+  version <- "0.11.0"
 
   # the project directory
   project <- getwd()

--- a/renv/settings.dcf
+++ b/renv/settings.dcf
@@ -1,0 +1,6 @@
+external.libraries:
+ignored.packages:
+package.dependency.fields: Imports, Depends, LinkingTo
+snapshot.type: implicit
+use.cache: TRUE
+vcs.ignore.library: TRUE


### PR DESCRIPTION
Here is the first iteration of potential changes to the research compendium for better accessibility and long-term reusability/understandability.

## Contents

- started more verbose README
- turned README.md into README.Rmd
- check if I can compile the Rmd documents in `docs/` > yes!
- based on [previous ideas](https://gitlab.com/nuest/ENSO/-/merge_requests/new/diffs?merge_request%5Bsource_branch%5D=research_compendium&merge_request%5Btarget_branch%5D=master), ...
  - configure MODISoptions to not ask any questions
  - don't open URLs when downloading MODIS data
  - update login method for data download
  - use `here::here(..)` for paths consistently [_INCOMPLETE_ - pending feedback]
  - MODIS download from `LPDAAC` did not work for me, and the other also has some errors:

```r
> source(here::here("code/00_modis_download.R"))
Loading ENSO
'outDirPath' does not exist and will be created in '/home/daniel/git/ENSO/data/processed/modis/'.

STORAGE:
_______________
localArcPath : /home/daniel/git/ENSO/data/raw_data/modis/ 
outDirPath   : /home/daniel/git/ENSO/data/processed/modis/ 


DOWNLOAD:
_______________
MODISserverOrder : LAADS 
dlmethod         : auto 
stubbornness     : high 
wait             : 0.5 
quiet            : TRUE 


PROCESSING:
_______________
GDAL           : 3.0.4 
MRT            : Enabled 
pixelSize      : asIn 
outProj        : asIn 
resamplingType : NN 
dataFormat     : GTiff 
cellchunk      : 1 


tables.gpkg already exists in the data/ folderCreating clear text file '~/.netrc' with Earthdata login credentials...

Downloading data into  data/raw_data/modis/processed/ndvi_peru_10 
########################
outProj          =  +proj=longlat +datum=WGS84 +no_defs  (if applicable, derived from Raster*/Spatial*/sf* object)
pixelSize        =  asIn  (if applicable, derived from Raster* object)
resamplingType   =  near 
Output Directory =  /home/daniel/git/ENSO/data/processed/modis/ndvi_peru_10 
########################
Downloading structure on 'LAADS' for: MOD13Q1.006
	... 2000 
	... 2001 
	... 2002 
	... 2003 
	... 2004 
	... 2005 
	... 2006 
	... 2007 
	... 2008 
	... 2009 
	... 2010 
	... 2011 
	... 2012 
	... 2013 
	... 2014 
	... 2015 
	... 2016 
	... 2017 
	... 2018 
	... 2019 
	... 2020 
sh: 1: 5: Bad file descriptor

[many more...]

sh: 1: 5: Bad file descriptor
sh: 1: 5: Bad file descriptor
Hm, I have to search for the file. Next time provide the full path and I'll be very fast!
Error in strsplit(x, ":") : non-character argument
```

## Open tasks

- [ ] Get data download working
- [ ] Get Binder working
  - https://github.com/rocker-org/rocker-versioned2/issues/88
  - probably requires installation of TinyTex packages in the Dockerfile, will have to test (note for later: lm-math, unicode-math, sectsty)
  - download data from Zenodo during build
- [ ] Let the Zenodo data set (https://zenodo.org/record/3981437) link back to the paper via the Zenodo metadata ("Related identifiers")
- [ ] run rendering of Rmd files on CI, for increased trust in workflow definition?
- [ ] run whole workflow in CI?

